### PR TITLE
falcon: correct initial mixer path for compress-voip-call

### DIFF
--- a/configs/mixer_paths.xml
+++ b/configs/mixer_paths.xml
@@ -86,7 +86,7 @@
 
 	<!-- Voip -->
 	<ctl name="SLIM_0_RX_Voice Mixer Voip" value="0" />
-	<ctl name="Voip_Tx Mixer PRI_MI2S_TX_Voip" value="0" />
+	<ctl name="Voip_Tx Mixer SLIM_0_TX_Voip" value="0" />
 	<ctl name="Internal BTSCO SampleRate" value="8000" />
 	<ctl name="INTERNAL_BT_SCO_RX_Voice Mixer Voip" value="0" />
 	<ctl name="Voip_Tx Mixer INTERNAL_BT_SCO_TX_Voip" value="0" />


### PR DESCRIPTION
Swapping out PRI_MI2S_TX_Voip for SLIM_0_TX_Voip was forgotten in
commit: 519a08ad3d14b0add5b6baf2e74cf9f630642b48.

RM-165
Change-Id: I4df2b215042abb8f20bb6ab1836c8990cca7e6ee